### PR TITLE
Support old module names

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,7 @@ setup_args = dict(
     name = "diffpy.structure",
     version = versiondata.get('DEFAULT', 'version'),
     packages = [('diffpy.' + p) for p in find_packages('src/diffpy')],
+    py_modules = ['diffpy.Structure'],
     package_dir = {'' : 'src'},
     test_suite = 'diffpy.structure.tests',
     include_package_data = True,

--- a/src/diffpy/Structure.py
+++ b/src/diffpy/Structure.py
@@ -24,7 +24,7 @@ This module is deprecated and will be removed in the future.
 
 
 import sys
-import importlib
+import importlib.abc
 from warnings import warn
 
 WMSG = "Module {!r} is deprecated.  Use {!r} instead."

--- a/src/diffpy/Structure.py
+++ b/src/diffpy/Structure.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+##############################################################################
+#
+# diffpy.structure  Complex Modeling Initiative
+#                   (c) 2017 Brookhaven Science Associates,
+#                   Brookhaven National Laboratory.
+#                   All rights reserved.
+#
+# File coded by:    Pavol Juhas
+#
+# See AUTHORS.txt for a list of people who contributed.
+# See LICENSE.txt for license information.
+#
+##############################################################################
+
+"""
+Support import of old camel-case module names with DeprecationWarning.
+
+The imported camel-case modules are aliases for the current module
+instances.  Their `__name__` attributes are thus all in lower-case.
+
+This module is deprecated and will be removed in the future.
+"""
+
+
+import sys
+import importlib
+from warnings import warn
+
+WMSG = "Module {!r} is deprecated.  Use {!r} instead."
+
+# ----------------------------------------------------------------------------
+
+class FindRenamedStructureModule(importlib.abc.MetaPathFinder):
+
+    prefix = 'diffpy.Structure.'
+
+    @classmethod
+    def find_spec(cls, fullname, path=None, target=None):
+        # only handle submodules of diffpy.Structure
+        if not fullname.startswith(cls.prefix):
+            return None
+        lcname = fullname.lower()
+        spec = importlib.util.find_spec(lcname)
+        if spec is not None:
+            spec.name = fullname
+            spec.loader = MapRenamedStructureModule
+        return spec
+
+# end of class FindRenamedStructureModule
+
+# ----------------------------------------------------------------------------
+
+class MapRenamedStructureModule(importlib.abc.Loader):
+    """
+    Loader for old camel-case module names.
+
+    Import the current module and alias it under the old name.
+    """
+
+    @staticmethod
+    def create_module(spec):
+        lcname = spec.name.lower()
+        mod = importlib.import_module(lcname)
+        sys.modules[spec.name] = mod
+        warn(WMSG.format(spec.name, lcname), DeprecationWarning, stacklevel=2)
+        return mod
+
+
+    @staticmethod
+    def exec_module(module):
+        return
+
+# end of class MapRenamedStructureModule
+
+# ----------------------------------------------------------------------------
+
+# import diffpy.Structure with deprecation warning
+import diffpy.structure
+sys.modules['diffpy.Structure'] = diffpy.structure
+
+warn(WMSG.format('diffpy.Structure', 'diffpy.structure'),
+     DeprecationWarning, stacklevel=2)
+
+# install meta path finder for diffpy.Structure submodules
+sys.meta_path.append(FindRenamedStructureModule)
+
+# End of file

--- a/src/diffpy/structure/tests/testoldimports.py
+++ b/src/diffpy/structure/tests/testoldimports.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+##############################################################################
+#
+# diffpy.structure  Complex Modeling Initiative
+#                   (c) 2017 Brookhaven Science Associates,
+#                   Brookhaven National Laboratory.
+#                   All rights reserved.
+#
+# File coded by:    Pavol Juhas
+#
+# See AUTHORS.txt for a list of people who contributed.
+# See LICENSE.txt for license information.
+#
+##############################################################################
+
+
+"""\
+Unit tests for imports of old camel-case names.
+"""
+
+
+import sys
+import warnings
+import importlib
+import unittest
+
+import diffpy
+
+# ----------------------------------------------------------------------------
+
+class TestOldImports(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        "Uncache any already-imported old modules."
+        for modname in tuple(sys.modules):
+            if modname.startswith('diffpy.Structure'):
+                del sys.modules[modname]
+        return
+
+
+    def test_00TopImport(self):
+        """check import of diffpy.Structure
+        """
+        with self.assertWarns(DeprecationWarning):
+            import diffpy.Structure as m0
+        self.assertIs(diffpy.structure, m0)
+        # second import should raise no warning
+        with warnings.catch_warnings():
+            warnings.simplefilter('error')
+            import diffpy.Structure as m1
+        self.assertIs(diffpy.structure, m1)
+        return
+
+
+    def test_O1SubmoduleImport(self):
+        """check import of diffpy.Structure submodules.
+        """
+        with self.assertWarns(DeprecationWarning):
+            import diffpy.Structure.SymmetryUtilities as symutil
+        self.assertIs(diffpy.structure.symmetryutilities, symutil)
+        with self.assertWarns(DeprecationWarning):
+            import diffpy.Structure.Parsers.P_cif as pcif
+        self.assertIs(diffpy.structure.parsers.p_cif, pcif)
+        self.assertRaises(ImportError, importlib.import_module,
+                          'diffpy.Structure.SSpaceGroups')
+        return
+
+# End of class TestOldImports
+
+# ----------------------------------------------------------------------------
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/diffpy/structure/tests/testoldimports.py
+++ b/src/diffpy/structure/tests/testoldimports.py
@@ -35,7 +35,7 @@ class TestOldImports(unittest.TestCase):
         "Uncache any already-imported old modules."
         for modname in tuple(sys.modules):
             if modname.startswith('diffpy.Structure'):
-                del sys.modules[modname]
+                del sys.modules[modname]    # pragma: no cover
         return
 
 


### PR DESCRIPTION
diffpy.structure modules were renamed to lower-case for the python3 branch.
This restores import under old names (with deprecation warning) to allow reuse
of old scripts and examples in cmi_exchange.

@CJ-Wright - can you please review this?