### PR TITLE
base and stdbase matrices bug

### DIFF
--- a/src/diffpy/Structure/lattice.py
+++ b/src/diffpy/Structure/lattice.py
@@ -192,10 +192,10 @@ class Lattice(object):
                 dtype=float )
         # standard Cartesian coordinates of lattice vectors
         self.stdbase = numpy.array( [
-                [ self.a,     cg*self.b,   cb*self.c ],
-                [ 0.0,        self.b*sg,   -car*sb*self.c ],
-                [ 0.0,        0.0,          1/self.cr    ] ],
-                dtype=float )
+                    [ self.a,     0.0,             0.0 ],
+                    [ cg*self.b,  self.b*sg,       0.0 ],
+                    [ cb*self.c,  -car*sb*self.c,  1/self.cr ] ],
+                    dtype=float )
         # Cartesian coordinates of lattice vectors
         self.base = numpy.dot(self.stdbase, self.baserot)
         self.recbase = numalg.inv(self.base)
@@ -249,9 +249,9 @@ class Lattice(object):
         self._gammar = math.degrees(math.acos(cgr))
         # standard orientation of lattice vectors
         self.stdbase = numpy.array( [
-                [ self.a,     cg*self.b,   cb*self.c ],
-                [ 0.0,        self.b*sg,   -car*sb*self.c ],
-                [ 0.0,        0.0,          1/self.cr    ] ],
+                [ self.a,     0.0,             0.0 ],
+                [ cg*self.b,  self.b*sg,       0.0],
+                [ cb*self.c,  -car*sb*self.c,  1/self.cr ] ],
                 dtype=float )
         # calculate unit cell rotation matrix,  base = stdbase*baserot
         self.baserot = numpy.dot(numalg.inv(self.stdbase), self.base)

--- a/src/diffpy/Structure/lattice.py
+++ b/src/diffpy/Structure/lattice.py
@@ -192,9 +192,9 @@ class Lattice(object):
                 dtype=float )
         # standard Cartesian coordinates of lattice vectors
         self.stdbase = numpy.array( [
-                [ 1.0/ar,    -cgr/sgr/ar,   cb*self.a ],
-                [ 0.0,        self.b*sa,    self.b*ca ],
-                [ 0.0,        0.0,          self.c    ] ],
+                [ self.a,     cg*self.b,   cb*self.c ],
+                [ 0.0,        self.b*sg,   -car*sb*self.c ],
+                [ 0.0,        0.0,          1/self.cr    ] ],
                 dtype=float )
         # Cartesian coordinates of lattice vectors
         self.base = numpy.dot(self.stdbase, self.baserot)
@@ -248,11 +248,11 @@ class Lattice(object):
         self._betar = math.degrees(math.acos(cbr))
         self._gammar = math.degrees(math.acos(cgr))
         # standard orientation of lattice vectors
-        self.stdbase = numpy.array([
-                [ 1.0/ar,   -cgr/sgr/ar,    cb*a ],
-                [ 0.0,       b*sa,          b*ca ],
-                [ 0.0,       0.0,           c    ]],
-                dtype=float)
+        self.stdbase = numpy.array( [
+                [ self.a,     cg*self.b,   cb*self.c ],
+                [ 0.0,        self.b*sg,   -car*sb*self.c ],
+                [ 0.0,        0.0,          1/self.cr    ] ],
+                dtype=float )
         # calculate unit cell rotation matrix,  base = stdbase*baserot
         self.baserot = numpy.dot(numalg.inv(self.stdbase), self.base)
         self.recbase = numalg.inv(self.base)


### PR DESCRIPTION
Your computation of the base and stdbase matrices appears to be incorrect. I have changed this, to compute these matrices correctly. I do not know if this error exists elsewhere in the DiffPy code, but you might want to look into that.  If this was not an error, can you please describe which coordinate convention you are using. Here is my source for the correct formula for the matrices: https://en.wikipedia.org/wiki/Fractional_coordinates#Conversion_to_Cartesian_coordinates
