### PR TITLE
Fix atom-structure pickle

### DIFF
--- a/src/diffpy/structure/structure.py
+++ b/src/diffpy/structure/structure.py
@@ -16,7 +16,6 @@
 """This module defines class Structure.
 """
 
-import collections
 import copy
 import numpy
 import codecs
@@ -25,6 +24,7 @@ import six
 from diffpy.structure.lattice import Lattice
 from diffpy.structure.atom import Atom
 from diffpy.structure.utils import _linkAtomAttribute, atomBareSymbol
+from diffpy.structure.utils import isiterable
 
 # ----------------------------------------------------------------------------
 
@@ -388,7 +388,7 @@ class Structure(list):
         # check if there is any string label that should be resolved
         scalarstringlabel = isinstance(idx, six.string_types)
         hasstringlabel = scalarstringlabel or (
-            isinstance(idx, collections.Iterable) and
+            isiterable(idx) and
             any(isinstance(ii, six.string_types) for ii in idx))
         # if not, use numpy indexing to resolve idx
         if not hasstringlabel:

--- a/src/diffpy/structure/structure.py
+++ b/src/diffpy/structure/structure.py
@@ -16,7 +16,7 @@
 """This module defines class Structure.
 """
 
-import copy
+import copy as copymod
 import numpy
 import codecs
 import six
@@ -95,9 +95,9 @@ class Structure(list):
 
 
     def copy(self):
-        '''Return a deep copy of this Structure object.
+        '''Return a copy of this Structure object.
         '''
-        return copy.copy(self)
+        return copymod.copy(self)
 
 
     def __copy__(self, target=None):
@@ -116,7 +116,7 @@ class Structure(list):
         # copy attributes as appropriate:
         target.title = self.title
         target.lattice = Lattice(self.lattice)
-        target.pdffit = copy.deepcopy(self.pdffit)
+        target.pdffit = copymod.deepcopy(self.pdffit)
         # copy all atoms to the target
         target[:] = self
         return target
@@ -332,7 +332,7 @@ class Structure(list):
 
         No return value.
         """
-        adup = copy and Atom(a) or a
+        adup = copy and copymod.copy(a) or a
         adup.lattice = self.lattice
         super(Structure, self).insert(idx, adup)
         return
@@ -464,7 +464,7 @@ class Structure(list):
 
         Return new Structure with a copy of Atom instances.
         '''
-        rv = copy.copy(self)
+        rv = copymod.copy(self)
         rv += other
         return rv
 
@@ -489,7 +489,7 @@ class Structure(list):
         '''
         otherset = set(other)
         keepindices = [i for i, a in enumerate(self) if not a in otherset]
-        rv = copy.copy(self[keepindices])
+        rv = copymod.copy(self[keepindices])
         return rv
 
 
@@ -513,7 +513,7 @@ class Structure(list):
 
         Return new Structure.
         '''
-        rv = copy.copy(self[:0])
+        rv = copymod.copy(self[:0])
         rv += n * self.tolist()
         return rv
 

--- a/src/diffpy/structure/structure.py
+++ b/src/diffpy/structure/structure.py
@@ -339,37 +339,36 @@ class Structure(list):
 
 
     def extend(self, atoms, copy=None):
-        """Extend Structure with the specified sequence of atoms.
+        """Extend Structure with an iterable of atoms.
 
         Update the `lattice` attribute of all added atoms.
 
         Parameters
         ----------
         atoms : iterable
-            The `Atom` instances to be appended to this Structure.
+            The `Atom` objects to be appended to this Structure.
         copy : bool, optional
             Flag for adding copies of Atom objects.
-            Make copies when `True`, append `atoms` as are when ``False``.
-            The default behavior is to make copies when `atoms` are
-            of `Structure` type or if the new atoms introduce repeated
-            instances.
+            Make copies when `True`, append `atoms` unchanged when ``False``.
+            The default behavior is to make copies when `atoms` are of
+            `Structure` type or if new atoms introduce repeated objects.
         """
         adups = (copymod.copy(a) for a in atoms)
         if copy is None:
             if isinstance(atoms, Structure):
-                extatoms = adups
+                newatoms = adups
             else:
                 memo = set(id(a) for a in self)
-                newatom = lambda a: (a if id(a) not in memo
-                                     else copymod.copy(a))
+                nextatom = lambda a: (a if id(a) not in memo
+                                      else copymod.copy(a))
                 mark = lambda a: (memo.add(id(a)), a)[-1]
-                extatoms = (mark(newatom(a)) for a in atoms)
+                newatoms = (mark(nextatom(a)) for a in atoms)
         elif copy:
-            extatoms = adups
+            newatoms = adups
         else:
-            extatoms = atoms
+            newatoms = atoms
         setlat = lambda a: (setattr(a, 'lattice', self.lattice), a)[-1]
-        super(Structure, self).extend(setlat(a) for a in extatoms)
+        super(Structure, self).extend(setlat(a) for a in newatoms)
         return
 
 

--- a/src/diffpy/structure/tests/teststructure.py
+++ b/src/diffpy/structure/tests/teststructure.py
@@ -240,7 +240,7 @@ class TestStructure(unittest.TestCase):
         self.assertEqual(6, len(stru))
         self.assertTrue(all(a.lattice is stru.lattice for a in stru))
         self.assertEqual(lst, stru.tolist()[:2])
-        self.assertNotEqual(stru[-1], cdse[-1])
+        self.assertFalse(stru[-1] is cdse[-1])
         return
 
 

--- a/src/diffpy/structure/tests/teststructure.py
+++ b/src/diffpy/structure/tests/teststructure.py
@@ -18,6 +18,7 @@
 
 
 import copy
+import pickle
 import unittest
 import numpy
 
@@ -654,6 +655,17 @@ class TestStructure(unittest.TestCase):
         self.assertTrue(numpy.allclose([0, 0.23], stru.B23))
         stru.B11 = stru.B22 = stru.B33 = stru.B12 = stru.B13 = stru.B23 = 0.0
         self.assertFalse(numpy.any(stru.U != 0.0))
+        return
+
+
+    def test_pickling(self):
+        """Make sure Atom in Structure can be consistently pickled.
+        """
+        stru = self.stru
+        a = stru[0]
+        self.assertTrue(a is stru[0])
+        a1, stru1 = pickle.loads(pickle.dumps((a, stru)))
+        self.assertTrue(a1 is stru1[0])
         return
 
 # End of class TestStructure

--- a/src/diffpy/structure/utils.py
+++ b/src/diffpy/structure/utils.py
@@ -16,7 +16,19 @@
 """Small shared functions.
 """
 
+import six
 import numpy
+
+if six.PY2:
+    from collections import Iterable as _Iterable
+else:
+    from collections.abc import Iterable as _Iterable
+
+
+def isiterable(obj):
+    """True if argument is iterable."""
+    rv = isinstance(obj, _Iterable)
+    return rv
 
 
 def isfloat(s):


### PR DESCRIPTION
CI - only, do not merge.
Fix Atom/Structure identity relation after pickling which broke in Python 3.7:
```
a1, stru1 = pickle.loads(pickle.dumps([stru[0], stru]))
assert a1 is stru1[0]
```

Fixes https://github.com/diffpy/diffpy.srfit/issues/56.
