### PR TITLE
Handle unknown `atom_site_aniso` block

### DIFF
--- a/src/diffpy/structure/tests/testp_cif.py
+++ b/src/diffpy/structure/tests/testp_cif.py
@@ -365,7 +365,6 @@ class TestP_cif(unittest.TestCase):
         return
 
 
-    @unittest.expectedFailure
     def test_unknown_aniso(self):
         "test CIF file with unknown values in the aniso block."
         with open(self.teiciffile) as fp:

--- a/src/diffpy/structure/tests/testp_cif.py
+++ b/src/diffpy/structure/tests/testp_cif.py
@@ -365,6 +365,19 @@ class TestP_cif(unittest.TestCase):
         return
 
 
+    @unittest.expectedFailure
+    def test_unknown_aniso(self):
+        "test CIF file with unknown values in the aniso block."
+        with open(self.teiciffile) as fp:
+            lines = fp.readlines()
+        lines[-4:] = ['  ?  ?  ?  ?  ?  ?  ?\n']
+        ciftxt = ''.join(lines)
+        stru = self.ptest.parse(ciftxt)
+        self.assertEqual(16, len(stru))
+        self.assertTrue(all(stru.anisotropy))
+        return
+
+
     def test_curly_brace(self):
         "verify loading of a CIF file with unquoted curly brace"
         ptest = self.ptest


### PR DESCRIPTION
Ignore it when the values are unknown, i.e., `?`.
CI only, for manual merge.