### PR TITLE
Add a space group string representation, tested

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,9 @@ nosetests.xml
 # version information
 setup.cfg
 /src/diffpy/*/version.cfg
+
+# PyCharm
+.idea
+
+# Coverage report
+htmlcov

--- a/.gitignore
+++ b/.gitignore
@@ -42,9 +42,3 @@ nosetests.xml
 # version information
 setup.cfg
 /src/diffpy/*/version.cfg
-
-# PyCharm
-.idea
-
-# Coverage report
-htmlcov

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- A string representation of `SpaceGroup` with key information.
+
 ### Changed
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Release notes
 
+## Unreleased - Version 3.0.2
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+
 ## Version 3.0.1 – 2019-06-27
 
 ### Added

--- a/src/diffpy/structure/spacegroupmod.py
+++ b/src/diffpy/structure/spacegroupmod.py
@@ -262,6 +262,19 @@ class SpaceGroup(object):
         self.pdb_name                = pdb_name
         self.symop_list              = symop_list
 
+    def __repr__(self):
+        """Return a string representation of the space group."""
+        return (
+                   "SpaceGroup #%i (%s, %s). Symmetry matrices: %i, "
+                   "point sym. matr.: %i"
+               ) % (
+            self.number,
+            self.short_name,
+            self.crystal_system[0] + self.crystal_system[1:].lower(),
+            self.num_sym_equiv,
+            self.num_primitive_sym_equiv,
+        )
+
 
     def iter_symops(self):
         """Iterate over all symmetry operations in the space group.

--- a/src/diffpy/structure/tests/testspacegroups.py
+++ b/src/diffpy/structure/tests/testspacegroups.py
@@ -88,30 +88,40 @@ class TestRoutines(unittest.TestCase):
 
     def test_spacegroup_representation(self):
         """Verify SpaceGroup.__repr__()."""
-        numbers = [1, 3, 16, 75, 143, 168, 229]
-        short_names = ["P1", "P2", "P222", "P4", "P3", "P6", "Im-3m"]
-        systems = [
-            "Triclinic",
-            "Monoclinic",
-            "Orthorhombic",
-            "Tetragonal",
-            "Trigonal",
-            "Hexagonal",
-            "Cubic",
-        ]
-        n_symmetry_matrices = [1, 2, 4, 4, 3, 6, 96]
-        n_point_symmetry_matrices = [1, 2, 4, 4, 3, 6, 48]
-        sg_dict = dict(zip(
-            numbers,
-            zip(short_names, systems, n_symmetry_matrices, n_point_symmetry_matrices)
-        ))
-        for key, value in sg_dict.items():
-            sg = GetSpaceGroup(key)
-            expected_str = (
-                               "SpaceGroup #%i (%s, %s). Symmetry matrices: %i, "
-                               "point sym. matr.: %i"
-                           ) % ((key,) + value)
-            self.assertEqual(sg.__repr__(), expected_str)
+        self.assertEqual(
+            repr(GetSpaceGroup(1)),
+            "SpaceGroup #1 (P1, Triclinic). Symmetry matrices: 1, point sym. matr.: 1"
+        )
+        self.assertEqual(
+            repr(GetSpaceGroup(3)),
+            "SpaceGroup #3 (P2, Monoclinic). Symmetry matrices: 2, point sym. matr.: 2"
+        )
+        self.assertEqual(
+            repr(GetSpaceGroup(16)),
+            (
+                "SpaceGroup #16 (P222, Orthorhombic). Symmetry matrices: 4, point sym. "
+                "matr.: 4"
+            )
+        )
+        self.assertEqual(
+            repr(GetSpaceGroup(75)),
+            "SpaceGroup #75 (P4, Tetragonal). Symmetry matrices: 4, point sym. matr.: 4"
+        )
+        self.assertEqual(
+            repr(GetSpaceGroup(143)),
+            "SpaceGroup #143 (P3, Trigonal). Symmetry matrices: 3, point sym. matr.: 3"
+        )
+        self.assertEqual(
+            repr(GetSpaceGroup(168)),
+            "SpaceGroup #168 (P6, Hexagonal). Symmetry matrices: 6, point sym. matr.: 6"
+        )
+        self.assertEqual(
+            repr(GetSpaceGroup(229)),
+            (
+                "SpaceGroup #229 (Im-3m, Cubic). Symmetry matrices: 96, point sym. "
+                "matr.: 48"
+            )
+        )
         return
 
 # End of class TestRoutines

--- a/src/diffpy/structure/tests/testspacegroups.py
+++ b/src/diffpy/structure/tests/testspacegroups.py
@@ -111,9 +111,8 @@ class TestRoutines(unittest.TestCase):
                                "SpaceGroup #%i (%s, %s). Symmetry matrices: %i, "
                                "point sym. matr.: %i"
                            ) % ((key,) + value)
-
             self.assertEqual(sg.__repr__(), expected_str)
-
+        return
 
 # End of class TestRoutines
 

--- a/src/diffpy/structure/tests/testspacegroups.py
+++ b/src/diffpy/structure/tests/testspacegroups.py
@@ -86,6 +86,35 @@ class TestRoutines(unittest.TestCase):
         self.assertEqual(len(SpaceGroupList), len(hset))
         return
 
+    def test_spacegroup_representation(self):
+        """Verify SpaceGroup.__repr__()."""
+        numbers = [1, 3, 16, 75, 143, 168, 229]
+        short_names = ["P1", "P2", "P222", "P4", "P3", "P6", "Im-3m"]
+        systems = [
+            "Triclinic",
+            "Monoclinic",
+            "Orthorhombic",
+            "Tetragonal",
+            "Trigonal",
+            "Hexagonal",
+            "Cubic",
+        ]
+        n_symmetry_matrices = [1, 2, 4, 4, 3, 6, 96]
+        n_point_symmetry_matrices = [1, 2, 4, 4, 3, 6, 48]
+        sg_dict = dict(zip(
+            numbers,
+            zip(short_names, systems, n_symmetry_matrices, n_point_symmetry_matrices)
+        ))
+        for key, value in sg_dict.items():
+            sg = GetSpaceGroup(key)
+            expected_str = (
+                               "SpaceGroup #%i (%s, %s). Symmetry matrices: %i, "
+                               "point sym. matr.: %i"
+                           ) % ((key,) + value)
+
+            self.assertEqual(sg.__repr__(), expected_str)
+
+
 # End of class TestRoutines
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

Hi!

I'm one of the developers of the orix Python package (https://github.com/pyxem/orix) for handling crystal orientation mapping data. We're depending on diffpy.structure for storage and handling of unit cell information in our `Phase` object, and will soon add a space group attribute via your `SpaceGroup` class to it. It would therefore be nice to have a string representation of `SpaceGroup`, hence this PR.

Result of this PR:

```python
>>> from diffpy.structure.spacegroupmod import GetSpaceGroup
# Before
>>> print(GetSpaceGroup(229))
<diffpy.structure.spacegroupmod.SpaceGroup object at 0x7f819481a490>
# After
>>> print(GetSpaceGroup(229))
SpaceGroup #229 (Im-3m, Cubic). Symmetry matrices: 96, point sym. matr.: 48
```

Added:
* a one-line `SpaceGroup.__repr__()` detailing space group number, short name, crystal system, number of symmetry matrices and number of point group symmetry matrices 
* a naive test for this method
* the PyCharm project directory `.idea` and the htmlcov directory returned by `$ coverage html` to `.gitignore`

Tests pass with Python 3.7 and Python 2.7 from Anaconda.

I'll be happy to shorten the string if you find it too long, or change it if you prefer another representation.