### PR TITLE
Added support for _space_group.name_H-M_ref keyword in CIF files

### DIFF
--- a/src/diffpy/structure/parsers/p_cif.py
+++ b/src/diffpy/structure/parsers/p_cif.py
@@ -472,6 +472,7 @@ class P_cif(StructureParser):
         sg_nameHall = (block.get('_space_group_name_Hall', '') or
                 block.get('_symmetry_space_group_name_Hall', ''))
         sg_nameHM = (block.get('_space_group_name_H-M_alt', '') or
+                block.get('_space_group_name_H-M_ref', '') or
                 block.get('_symmetry_space_group_name_H-M', ''))
         self.cif_sgname = (sg_nameHall or sg_nameHM or None)
         sgid = (block.get('_space_group_IT_number', '') or

--- a/src/diffpy/structure/tests/testdata/Ni_ref.cif
+++ b/src/diffpy/structure/tests/testdata/Ni_ref.cif
@@ -1,0 +1,21 @@
+data_2102245
+_cell_length_a 3.562
+_cell_length_b 3.562
+_cell_length_c 3.562
+_cell_angle_alpha 90.00000000
+_cell_angle_beta 90.00000000
+_cell_angle_gamma 90.00000000
+_space_group_name_H-M_ref 'F m -3 m'
+
+
+loop_
+_atom_site_label
+_atom_site_type_symbol
+_atom_site_fract_x
+_atom_site_fract_y
+_atom_site_fract_z
+_atom_site_occupancy
+_atom_site_adp_type
+_atom_site_U_iso_or_equiv
+Ni Ni 0.00000000 0.00000000 0.00000000 1.00000000 Uiso 0.025
+

--- a/src/diffpy/structure/tests/testp_cif.py
+++ b/src/diffpy/structure/tests/testp_cif.py
@@ -71,6 +71,7 @@ class TestP_cif(unittest.TestCase):
     graphiteciffile = datafile('graphite.cif')
     cdsebulkpdffitfile = datafile('CdSe_bulk.stru')
     teiciffile = datafile('TeI.cif')
+    refciffile = datafile('Ni_ref.cif')
     places = 6
 
 
@@ -334,6 +335,14 @@ class TestP_cif(unittest.TestCase):
         self.assertTrue(all(stru.anisotropy))
         return
 
+    def test_spacegroup_ref(self):
+        "verify space group reference"
+        pfile = self.pfile
+        pfile.parseFile(self.refciffile)
+        sg = pfile.spacegroup
+        self.assertEqual('Fm-3m', sg.short_name)
+
+        return
 
     def test_adp_type_ani(self):
         "verify adp type override to anisotropic"


### PR DESCRIPTION
This keyword is a tightly defined version of the keyword which can be used to generate the symmetry operations of the reference setting, but only one form of this symbol (that given in the list of values specified by the dictionary) can be used for a given space group.

```
International Tables for Crystallography Volume G: Definition and exchange of crystallographic data
Series: International Tables for Crystallography G
Author(s): S. R. Hall, B. McMahon (auth.), S. R. Hall, B. McMahon (eds.)
Publisher: Springer Netherlands
Year: 2005
ISBN: 1402042906; 9781402054112; 1402054114;
```

p. 461