### PR TITLE
Replace deprecated pkg_resources with importlib pt3

### DIFF
--- a/src/diffpy/structure/tests/testutils.py
+++ b/src/diffpy/structure/tests/testutils.py
@@ -19,6 +19,8 @@
 # helper functions
 
 def datafile(filename):
-    from pkg_resources import resource_filename
-    rv = resource_filename(__name__, "testdata/" + filename)
-    return rv
+    from importlib.resources import as_file, files
+
+    ref = files(__package__) / ("testdata/" + filename)
+    with as_file(ref) as rv:
+        return rv


### PR DESCRIPTION
moving from `pkg_resources` to `importlib.resources`