### PR TITLE
remove prerelease from build docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,6 @@ name: Build and Deploy Documentation
 on:
   release:
     types:
-      - prereleased
       - published
   workflow_dispatch:
 


### PR DESCRIPTION
Looked into the deployed api docs it seems like it's not a good idea to build and deploy docs for pre-release. Pre-release version shouldn't count as the latest version.