### PR TITLE
add dynamic dependency in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "diffpy.structure"
-dynamic=['version']
+dynamic=['version', 'dependencies']
 authors = [
   { name="Simon J.L. Billinge group", email="simon.billinge@gmail.com" },
 ]
@@ -47,6 +47,9 @@ where = ["src"]  # list of folders that contain the packages (["."] by default)
 include = ["*"]  # package names should match these glob patterns (["*"] by default)
 exclude = ["diffpy.structure.tests*"]  # exclude packages matching these glob patterns (empty by default)
 namespaces = false  # to disable scanning PEP 420 namespaces (true by default)
+
+[tool.setuptools.dynamic]
+dependencies = {file = ["requirements/run.txt"]}
 
 [tool.black]
 line-length = 115


### PR DESCRIPTION
closes #97 

@sbillinge Please check and better test it on your setup.

We probably want this in the cookiecutter too, maybe also change the worked packages.

Another thing that might worth notice is do we want to include `requirements/build.txt`? This is specific to `diffpy.pdffit2`'s `gsl` dependency. However `setuptool` and `python` are included, which in theory should already be present if a user is installing this package to a conda environment with python installed.