### PR TITLE
Fix #124: Support pathlib.Path in loadStructure and add test

### DIFF
--- a/src/diffpy/structure/__init__.py
+++ b/src/diffpy/structure/__init__.py
@@ -37,6 +37,7 @@ Exceptions:
 
 # Interface definitions ------------------------------------------------------
 
+import os 
 from diffpy.structure.atom import Atom
 from diffpy.structure.lattice import Lattice
 from diffpy.structure.parsers import getParser
@@ -55,8 +56,7 @@ def loadStructure(filename, fmt="auto", **kw):
 
     Parameters
     ----------
-
-    filename : str
+    filename : str or pathlib.Path
         Path to the file to be loaded.
     fmt : str, Optional
         Format of the structure file such as 'cif' or 'xyz'. Must be
@@ -74,7 +74,7 @@ def loadStructure(filename, fmt="auto", **kw):
         Return a more specific PDFFitStructure type for 'pdffit'
         and 'discus' formats.
     """
-
+    filename = os.fspath(filename)  # This handles str, Path, and os.PathLike
     p = getParser(fmt, **kw)
     rv = p.parseFile(filename)
     return rv

--- a/tests/test_loadstructure.py
+++ b/tests/test_loadstructure.py
@@ -59,6 +59,16 @@ class TestLoadStructure(unittest.TestCase):
         self.assertRaises(TypeError, loadStructure, f, eps=1e-10)
         return
 
+    def test_cif_pathlib(self):
+        """check loading CIF file using pathlib.Path input"""
+        from pathlib import Path
+        f = self.datafile("PbTe.cif")
+        f_path = Path(f)  # Convert to Path object
+        stru = loadStructure(f_path)
+        self.assertTrue(isinstance(stru, Structure))
+        self.assertFalse(isinstance(stru, PDFFitStructure))
+        return
+
 
 # End of class TestLoadStructure
 


### PR DESCRIPTION
This PR resolves [#124](https://github.com/diffpy/diffpy.structure/issues/124) by adding support for `pathlib.Path` inputs in `loadStructure`.

### Summary:
- Adds `os.fspath(filename)` to allow `str`, `pathlib.Path`, and `os.PathLike` file inputs.
- Updates the docstring to clarify accepted types.
- Adds a new unit test (`test_cif_pathlib`) to verify that `loadStructure` accepts `Path` objects.
- Confirmed functionality with both automated and manual tests.

### Note:
Some unrelated tests are failing due to `YappsSyntaxError` now being raised by PyCifRW instead of `StructureFormatError`. These issues predate this change and are unrelated to the fix provided here.