### PR TITLE
docs: add the instruction to reinstall `pycifrw`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -99,6 +99,10 @@ and run the following ::
 
         pip install .
 
+In ``diffpy.structure>=3.3.1``, please ensure the dependency ``pycifrw`` is installed from ``conda-froge`` ::
+
+        conda install pycifrw
+
 Getting Started
 ---------------
 

--- a/news/reinstall-pycifrw.rst
+++ b/news/reinstall-pycifrw.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Add the instruction to reinstsall ``pycifrw`` in ``README.rst``.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
### What problem does this PR address

Adding the instruction to reinstall `pycifrw` as mentioned in #144 

### What should the reviewer(s) do

Please check the modified `README.rst`