### PR TITLE
fix: let tests compatible to newer versions of `pycifrw`

### DIFF
--- a/news/catch-YapsSyntaxError.rst
+++ b/news/catch-YapsSyntaxError.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Let ``diffpy.structure`` pass the tests with ``pycifrw`` installed from ``PyPI``.
+
+**Security:**
+
+* <news item>

--- a/src/diffpy/structure/parsers/p_cif.py
+++ b/src/diffpy/structure/parsers/p_cif.py
@@ -36,6 +36,7 @@ import numpy
 from diffpy.structure import Atom, Lattice, Structure
 from diffpy.structure.parsers import StructureParser
 from diffpy.structure.structureerrors import StructureFormatError
+from CifFile.yapps3_compiled_rt import YappsSyntaxError
 
 # ----------------------------------------------------------------------------
 
@@ -408,7 +409,7 @@ class P_cif(StructureParser):
                     # stop after reading the first structure
                     if self.stru is not None:
                         break
-        except (StarError, ValueError, IndexError) as err:
+        except (YappsSyntaxError, StarError, ValueError, IndexError) as err:
             exc_type, exc_value, exc_traceback = sys.exc_info()
             emsg = str(err).strip()
             e = StructureFormatError(emsg)


### PR DESCRIPTION
### What problem does this PR address?

Fix the failed tests as mentioned in #144 

The newest version of `pycifrw` in `conda-forge` is `4.4.6`, and in `PyPI` is `5.0.1`. Some `StarError` is changed to `YappsSyntaxError` in the newer version of `pycifrw` and can not be caught by the parser in `diffpy.structure`. This is why tests failed in `diffpy.structure=3.3.1rc0`.

### What should the reviewer(s) do?

Please check if catching the `YappsSyntaxError` as StructureFormatError is what we want.