### PR TITLE
chore: fix CI badge in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,8 +15,8 @@
 .. |Black| image:: https://img.shields.io/badge/code_style-black-black
         :target: https://github.com/psf/black
 
-.. |CI| image:: https://github.com/diffpy/diffpy.structure/actions/workflows/matrix-and-codecov-on-merge-to-main.yml/badge.svg
-        :target: https://github.com/diffpy/diffpy.structure/actions/workflows/matrix-and-codecov-on-merge-to-main.yml
+.. |CI| image:: https://github.com/diffpy/diffpy.structure/actions/workflows/matrix-and-codecov.yml/badge.svg
+        :target: https://github.com/diffpy/diffpy.structure/actions/workflows/matrix-and-codecov.yml
 
 .. |Codecov| image:: https://codecov.io/gh/diffpy/diffpy.structure/branch/main/graph/badge.svg
         :target: https://codecov.io/gh/diffpy/diffpy.structure

--- a/news/CI-badge-fix.rst
+++ b/news/CI-badge-fix.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* No News Added: fix CI badge and target in README.rst
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
@sbillinge ready to review. Note that because in the new `skpkg` workflow we changed the name of the yaml file that related to CI, so now with the previous link in the `README.rst` the CI badge could not show up. Now we change to the correct workflow and should show up.