### PR TITLE
chore: Fix internal deprecated function usage

### DIFF
--- a/news/fix-internal-deps.rst
+++ b/news/fix-internal-deps.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* No news needed: fix internal use of deprecated functions.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/diffpy/structure/__init__.py
+++ b/src/diffpy/structure/__init__.py
@@ -101,10 +101,10 @@ def load_structure(filename, fmt="auto", **kw):
         Path to the file to be loaded.
     fmt : str, Optional
         Format of the structure file such as 'cif' or 'xyz'. Must be
-        one of the formats listed by the `parsers.inputFormats` function.
+        one of the formats listed by the `parsers.input_formats` function.
         When 'auto', all supported formats are tried in a sequence.
     kw : Optional
-        Extra keyword arguments that are passed to `parsers.getParser`
+        Extra keyword arguments that are passed to `parsers.get_parser`
         function. These configure the dedicated Parser object that
         is used to read content in filename.
 

--- a/src/diffpy/structure/apps/anyeye.py
+++ b/src/diffpy/structure/apps/anyeye.py
@@ -187,7 +187,7 @@ def convert_structure_file(pd):
     fmt = pd.get("format", "auto")
     stru = None
     if fmt == "auto":
-        stru, fmt = loadStructureFile(strufile)
+        stru, fmt = load_structure_file(strufile)
         pd["fmt"] = fmt
     # if fmt is recognized by the viewer, use as is
     if fmt in pd["formats"] and pd["formula"] is None:

--- a/src/diffpy/structure/lattice.py
+++ b/src/diffpy/structure/lattice.py
@@ -159,8 +159,8 @@ class Lattice(object):
     Note
     ----
     The array attributes are read-only. They get updated by changing
-    some lattice parameters or by calling the `setLatPar()` or
-    `setLatBase()` methods.
+    some lattice parameters or by calling the `set_latt_parms()` or
+    `set_new_latt_base_vec()` methods.
 
     Examples
     --------
@@ -757,13 +757,13 @@ class Lattice(object):
         I3 = numpy.identity(3, dtype=float)
         rotbaseI3diff = max(numpy.reshape(numpy.fabs(self.baserot - I3), 9))
         cartlatpar = numpy.array([1.0, 1.0, 1.0, 90.0, 90.0, 90.0])
-        latpardiff = cartlatpar - self.abcABG()
+        latpardiff = cartlatpar - self.cell_parms()
         if rotbaseI3diff > self._epsilon:
             s = "Lattice(base=%r)" % self.base
         elif numpy.fabs(latpardiff).max() < self._epsilon:
             s = "Lattice()"
         else:
-            s = "Lattice(a=%g, b=%g, c=%g, alpha=%g, beta=%g, gamma=%g)" % self.abcABG()
+            s = "Lattice(a=%g, b=%g, c=%g, alpha=%g, beta=%g, gamma=%g)" % self.cell_parms()
         return s
 
 

--- a/src/diffpy/structure/parsers/__init__.py
+++ b/src/diffpy/structure/parsers/__init__.py
@@ -16,7 +16,7 @@
 
 The recognized structure formats are defined by subclassing `StructureParser`,
 by convention these classes are named `P_<format>.py`. The parser classes should
-to override the `parseLines()` and `toLines()` methods of `StructureParser`.
+to override the `parse_lines()` and `to_lines()` methods of `StructureParser`.
 Any structure parser needs to be registered in `parser_index` module.
 
 For normal usage it should be sufficient to use the routines provided
@@ -25,9 +25,9 @@ in this module.
 Content:
     * StructureParser: base class for a concrete Parser
     * parser_index: dictionary of known structure formats
-    * getParser: factory for Parser at given format
-    * inputFormats: list of available input formats
-    * outputFormats: list of available output formats
+    * get_parser: factory for Parser at given format
+    * input_formats: list of available input formats
+    * output_formats: list of available output formats
 """
 
 from diffpy.structure.parsers.parser_index_mod import parser_index

--- a/src/diffpy/structure/parsers/p_auto.py
+++ b/src/diffpy/structure/parsers/p_auto.py
@@ -14,7 +14,7 @@
 ##############################################################################
 """Parser for automatic file format detection.
 
-This Parser does not provide the the `toLines()` method.
+This Parser does not provide the the `to_lines()` method.
 """
 
 import os

--- a/src/diffpy/structure/parsers/p_cif.py
+++ b/src/diffpy/structure/parsers/p_cif.py
@@ -19,7 +19,7 @@ Attributes
 rx_float : re.Pattern
     The constant regular expression for `leading_float()`.
 symvec : dict
-    The helper dictionary for `getSymOp()`.
+    The helper dictionary for `get_symop()`.
 
 Note
 ----
@@ -362,7 +362,6 @@ class P_cif(StructureParser):
         """
         return self.parse_lines(lines)
 
-    @deprecated(parseLines_deprecation_msg)
     def parse_lines(self, lines):
         """Parse list of lines in CIF format.
 

--- a/src/diffpy/structure/parsers/p_discus.py
+++ b/src/diffpy/structure/parsers/p_discus.py
@@ -140,7 +140,7 @@ class P_discus(StructureParser):
                 raise StructureFormatError(emsg)
             # take care of superlattice
             if self.stru.pdffit["ncell"][:3] != [1, 1, 1]:
-                latpars = list(self.stru.lattice.abcABG())
+                latpars = list(self.stru.lattice.cell_parms())
                 superlatpars = [latpars[i] * self.stru.pdffit["ncell"][i] for i in range(3)] + latpars[3:]
                 superlattice = Lattice(*superlatpars)
                 self.stru.place_in_lattice(superlattice)
@@ -215,7 +215,7 @@ class P_discus(StructureParser):
                 raise StructureFormatError(emsg)
             # take care of superlattice
             if self.stru.pdffit["ncell"][:3] != [1, 1, 1]:
-                latpars = list(self.stru.lattice.abcABG())
+                latpars = list(self.stru.lattice.cell_parms())
                 superlatpars = [latpars[i] * self.stru.pdffit["ncell"][i] for i in range(3)] + latpars[3:]
                 superlattice = Lattice(*superlatpars)
                 self.stru.place_in_lattice(superlattice)
@@ -268,7 +268,7 @@ class P_discus(StructureParser):
         if stru_pdffit.get("stepcut", 0.0) > 0.0:
             line = "shape   stepcut, %g" % stru_pdffit["stepcut"]
             lines.append(line)
-        lines.append("cell   %9.6f, %9.6f, %9.6f, %9.6f, %9.6f, %9.6f" % self.stru.lattice.abcABG())
+        lines.append("cell   %9.6f, %9.6f, %9.6f, %9.6f, %9.6f, %9.6f" % self.stru.lattice.cell_parms())
         lines.append("ncell  %9i, %9i, %9i, %9i" % (1, 1, 1, len(self.stru)))
         lines.append("atoms")
         for a in self.stru:

--- a/src/diffpy/structure/parsers/p_pdb.py
+++ b/src/diffpy/structure/parsers/p_pdb.py
@@ -215,9 +215,9 @@ class P_pdb(StructureParser):
                     sc[2, :] = [float(x) for x in line[10:40].split()]
                     scaleU[2] = float(line[45:55])
                     base = numpy.transpose(numpy.linalg.inv(sc))
-                    abcABGcryst = numpy.array(stru.lattice.abcABG())
+                    abcABGcryst = numpy.array(stru.lattice.cell_parms())
                     stru.lattice.set_new_latt_base_vec(base)
-                    abcABGscale = numpy.array(stru.lattice.abcABG())
+                    abcABGscale = numpy.array(stru.lattice.cell_parms())
                     reldiff = numpy.fabs(1.0 - abcABGscale / abcABGcryst)
                     if not numpy.all(reldiff < 1.0e-4):
                         emsg = "%d: " % p_nl + "SCALE and CRYST1 are not consistent."

--- a/src/diffpy/structure/parsers/p_vesta.py
+++ b/src/diffpy/structure/parsers/p_vesta.py
@@ -184,7 +184,7 @@ class P_vesta(StructureParser):
                 emsg = "VESTA file is missing STRUC lattice parameters"
                 raise StructureFormatError(emsg)
 
-            stru.lattice.setLatPar(
+            stru.lattice.set_latt_parms(
                 a=latt_abc[0],
                 b=latt_abc[1],
                 c=latt_abc[2],

--- a/src/diffpy/structure/parsers/structureparser.py
+++ b/src/diffpy/structure/parsers/structureparser.py
@@ -98,7 +98,7 @@ class StructureParser(object):
     def parse(self, s):
         """Create `Structure` instance from a string."""
         lines = s.rstrip("\r\n").split("\n")
-        stru = self.parseLines(lines)
+        stru = self.parse_lines(lines)
         return stru
 
     def tostring(self, stru):

--- a/src/diffpy/structure/pdffitstructure.py
+++ b/src/diffpy/structure/pdffitstructure.py
@@ -98,10 +98,10 @@ class PDFFitStructure(Structure):
         return self.read_structure(s, format)
 
     def read_structure(self, s, format="auto"):
-        """Same as `Structure.readStr`, but update `spcgr` value in
-        `self.pdffit` when parser can get spacegroup.
+        """Same as `Structure.read_structure`, but update `spcgr` value
+        in `self.pdffit` when parser can get spacegroup.
 
-        See `Structure.readStr()` for more info.
+        See `Structure.read_structure()` for more info.
 
         Parameters
         ----------

--- a/src/diffpy/structure/spacegroups.py
+++ b/src/diffpy/structure/spacegroups.py
@@ -748,7 +748,7 @@ def is_space_group_identifier(sgid):
     bool
     """
     try:
-        GetSpaceGroup(sgid)
+        get_space_group(sgid)
         rv = True
     except ValueError:
         rv = False

--- a/src/diffpy/structure/symmetryutilities.py
+++ b/src/diffpy/structure/symmetryutilities.py
@@ -602,7 +602,7 @@ class GeneratorSite(object):
         self.pparameters = []
         self.Uparameters = []
         # fill in the values
-        sites, ops, mult = expandPosition(spacegroup, xyz, sgoffset, eps)
+        sites, ops, mult = expand_position(spacegroup, xyz, sgoffset, eps)
         invariants = _find_invariants(ops)
         # shift self.xyz exactly to the special position
         if mult > 1:
@@ -613,7 +613,7 @@ class GeneratorSite(object):
             if numpy.any(dxyz != 0.0):
                 self.xyz = xyz + dxyz
                 self.xyz[numpy.fabs(self.xyz) < self.eps] = 0.0
-                sites, ops, mult = expandPosition(spacegroup, self.xyz, self.sgoffset, eps)
+                sites, ops, mult = expand_position(spacegroup, self.xyz, self.sgoffset, eps)
                 invariants = _find_invariants(ops)
         # self.xyz, sites, ops are all adjusted here
         self.eqxyz = sites
@@ -1322,7 +1322,7 @@ class SymmetryConstraints(object):
 
         See also
         --------
-        positionFormulas()
+        position_formulas()
 
         Parameters
         ----------
@@ -1429,7 +1429,7 @@ class SymmetryConstraints(object):
 
         See Also
         --------
-        UFormulas()
+        u_formulas()
 
         Parameters
         ----------
@@ -1459,7 +1459,7 @@ if __name__ == "__main__":
     g = GeneratorSite(sg100, site, Uij=Uij)
     fm100 = g.position_formula(site)
     print("g = GeneratorSite(sg100, %r)" % site)
-    print("g.positionFormula(%r) = %s" % (site, fm100))
+    print("g.position_formula(%r) = %s" % (site, fm100))
     print("g.pparameters =", g.pparameters)
     print("g.Uparameters =", g.Uparameters)
-    print("g.UFormula(%r) =" % site, g.u_formula(site))
+    print("g.u_formula(%r) =" % site, g.u_formula(site))


### PR DESCRIPTION
All these functions being used internally caused deprecation warnings to be emitted when they weren't being used. Also, one new function was flagged as deprecated when it isn't supposed to be. 